### PR TITLE
Provide handlers with MicroserviceMsgserice instance so they can reuse

### DIFF
--- a/src/main/java/gov/usgs/cida/microservices/api/messaging/MicroserviceHandler.java
+++ b/src/main/java/gov/usgs/cida/microservices/api/messaging/MicroserviceHandler.java
@@ -3,11 +3,13 @@ package gov.usgs.cida.microservices.api.messaging;
 import java.io.IOException;
 import java.util.Map;
 
+import gov.usgs.cida.microservices.messaging.MicroserviceMsgservice;
+
 /**
  *
  * @author dmsibley
  */
 public interface MicroserviceHandler {
-	public void handle(String requestId, String serviceRequestId, Map<String, Object> params, byte[] body) throws IOException;
+	public void handle(String requestId, String serviceRequestId, Map<String, Object> params, byte[] body, MicroserviceMsgservice msgService) throws IOException;
 	public Iterable<Map<String, Object>> getBindings(String serviceName); 
 }

--- a/src/main/java/gov/usgs/cida/microservices/messaging/MicroserviceConsumer.java
+++ b/src/main/java/gov/usgs/cida/microservices/messaging/MicroserviceConsumer.java
@@ -50,7 +50,7 @@ public class MicroserviceConsumer extends DefaultConsumer  {
 		String requestId = MessageUtils.getStringFromHeaders(params, "requestId");
 		String serviceRequestId = MessageUtils.getStringFromHeaders(params, "serviceRequestId");
 		try {
-			this.handler.handle(requestId, serviceRequestId, params, body);
+			this.handler.handle(requestId, serviceRequestId, params, body, this.msgService);
 
 			//TODO turn off autoack?
 			//For error handlers, we probably want autoack off so that there can be multiple error handlers

--- a/src/main/java/gov/usgs/cida/microservices/messaging/MicroserviceMsgservice.java
+++ b/src/main/java/gov/usgs/cida/microservices/messaging/MicroserviceMsgservice.java
@@ -36,7 +36,7 @@ import java.util.Set;
  *
  * @author thongsav
  */
-public final class MicroserviceMsgservice implements Closeable, MessagingClient, MessageBasedMicroservice {
+public class MicroserviceMsgservice implements Closeable, MessagingClient, MessageBasedMicroservice {
 
 	private static final Logger log = LoggerFactory.getLogger(MicroserviceMsgservice.class);
 


### PR DESCRIPTION
and/or do not have to get a handle on it via the global factory
singleton.